### PR TITLE
Check for string type on yaml tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Obsidian Changelog
 
+- Fixes and issue where tags as objects woudl crash the plugin
 ## [Add week placeholder] - 2023-07-14
 
 - Adds a {week} template placeholder (thanks @adamadamsmusic)

--- a/src/utils/yaml.tsx
+++ b/src/utils/yaml.tsx
@@ -103,13 +103,13 @@ export function yamlTagsForString(str: string) {
     if (yamlHas(parsedYAML, "tag")) {
       if (Array.isArray(parsedYAML.tag)) {
         foundTags = [...parsedYAML.tag];
-      } else {
+      } else if (typeof parsedYAML.tag === "string") {
         foundTags = [...parsedYAML.tag.split(",").map((tag: string) => tag.trim())];
       }
     } else if (yamlHas(parsedYAML, "tags")) {
       if (Array.isArray(parsedYAML.tags)) {
         foundTags = [...parsedYAML.tags];
-      } else {
+      } else if (typeof parsedYAML.tags === "string") {
         foundTags = [...parsedYAML.tags.split(",").map((tag: string) => tag.trim())];
       }
     }


### PR DESCRIPTION
This just checks for string types before running string operations. Prevents other primitives or objects from passing. 