### PR TITLE
Fall back to empty object in cache check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Obsidian Changelog
 
+## [Menubar cache bug fixes] - 2023-09-15
+- Fixes a bug where the cache fallback would crash the extension
+
 ## [Apply templates on task file name] - 2023-08-5
 - The Append Task command will now apply template placeholders to file name for dynamic file names
 

--- a/src/utils/data/cache.tsx
+++ b/src/utils/data/cache.tsx
@@ -55,7 +55,7 @@ export function cacheExistForVault(vault: Vault) {
 
 export function updateNoteInCache(vault: Vault, note: Note) {
   if (cacheExistForVault(vault)) {
-    const data = JSON.parse(cache.get(vault.name) ?? "");
+    const data = JSON.parse(cache.get(vault.name) ?? "{}");
     data.notes = data.notes.map((n: Note) => (n.path === note.path ? note : n));
     cache.set(vault.name, JSON.stringify(data));
   }
@@ -69,7 +69,7 @@ export function updateNoteInCache(vault: Vault, note: Note) {
  */
 export function deleteNoteFromCache(vault: Vault, note: Note) {
   if (cacheExistForVault(vault)) {
-    const data = JSON.parse(cache.get(vault.name) ?? "");
+    const data = JSON.parse(cache.get(vault.name) ?? "{}");
     data.notes = data.notes.filter((n: Note) => n.path !== note.path);
     cache.set(vault.name, JSON.stringify(data));
   }
@@ -77,7 +77,7 @@ export function deleteNoteFromCache(vault: Vault, note: Note) {
 
 export function getNotesFromCache(vault: Vault) {
   if (cacheExistForVault(vault)) {
-    const data = JSON.parse(cache.get(vault.name) ?? "");
+    const data = JSON.parse(cache.get(vault.name) ?? "{}");
     if (data.lastCached > Date.now() - 1000 * 60 * 5) {
       const notes_ = data.notes;
       console.log("Returning cached notes");


### PR DESCRIPTION
Just updates the cache fallback value from `""` to `"{}"` to prevent error.