### PR TITLE
Add option to open in default app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Obsidian Changelog
 
+## [New features and bugfixes] - 2023-10-12
+- Adds extension setting to open note in default application
+- Adds quick actions to the Random Note command
+
 ## [Update search starting sort] - 2023-10-12
 
 - Search now shows the most recent notes first

--- a/package.json
+++ b/package.json
@@ -136,8 +136,12 @@
               "value": "obsidian"
             },
             {
-              "title": "Open in new Pane",
+              "title": "Open in new Obsidian tab",
               "value": "newpane"
+            },
+            {
+              "title": "Open in default app",
+              "value": "defaultapp"
             }
           ]
         }
@@ -222,8 +226,12 @@
               "value": "obsidian"
             },
             {
-              "title": "Open in new Pane",
+              "title": "Open in new Obsidian tab",
               "value": "newpane"
+            },
+            {
+              "title": "Open in default app",
+              "value": "defaultapp"
             }
           ]
         }
@@ -416,8 +424,12 @@
               "value": "obsidian"
             },
             {
-              "title": "Open in new Pane",
+              "title": "Open in new Obsidian tab",
               "value": "newpane"
+            },
+            {
+              "title": "Open in default app",
+              "value": "defaultapp"
             }
           ]
         }

--- a/src/components/NoteQuickLook.tsx
+++ b/src/components/NoteQuickLook.tsx
@@ -1,15 +1,24 @@
-import { Detail } from "@raycast/api";
-import { Note } from "../utils/interfaces";
+import { Action, ActionPanel, Detail, Icon } from "@raycast/api";
+import { Note, Vault } from "../utils/interfaces";
 import { filterContent } from "../utils/utils";
+import { NoteActions, OpenNoteActions } from "../utils/actions";
+import { renewCache } from "../utils/data/cache";
 
-export function NoteQuickLook(props: { showTitle: boolean; note: Note }) {
-  const { note, showTitle } = props;
+export function NoteQuickLook(props: { showTitle: boolean; note: Note; vault: Vault; allNotes: Note[] }) {
+  const { note, showTitle, allNotes, vault } = props;
 
   return (
     <Detail
       isLoading={note === undefined}
       navigationTitle={showTitle ? note.title : ""}
       markdown={filterContent(note.content)}
+      actions={
+        <ActionPanel>
+          <OpenNoteActions note={note} notes={allNotes} vault={vault} />
+          <NoteActions notes={allNotes} note={note} vault={vault} />
+          <Action title="Reload Notes" icon={Icon.ArrowClockwise} onAction={() => renewCache(vault)} />
+        </ActionPanel>
+      }
     />
   );
 }

--- a/src/components/RandomNote.tsx
+++ b/src/components/RandomNote.tsx
@@ -7,5 +7,5 @@ export function RandomNote(props: { vault: Vault; showTitle: boolean }) {
   const [notes] = useNotes(vault);
   const randomNote = notes[Math.floor(Math.random() * notes.length)];
 
-  return <NoteQuickLook note={randomNote} showTitle={showTitle}></NoteQuickLook>;
+  return <NoteQuickLook note={randomNote} vault={vault} showTitle={showTitle} allNotes={notes} />;
 }

--- a/src/utils/actions.tsx
+++ b/src/utils/actions.tsx
@@ -1,6 +1,15 @@
-import { Action, getPreferenceValues, Icon, Color, List, ActionPanel, confirmAlert } from "@raycast/api";
+import {
+  Action,
+  getPreferenceValues,
+  Icon,
+  Color,
+  List,
+  ActionPanel,
+  confirmAlert,
+  getDefaultApplication,
+} from "@raycast/api";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import { AppendNoteForm } from "../components/AppendNoteForm";
 import { EditNote } from "../components/EditNote";
@@ -143,8 +152,24 @@ export function DeleteNoteAction(props: { note: Note; vault: Vault }) {
 }
 
 export function QuickLookAction(props: { note: Note; notes: Note[]; vault: Vault }) {
+  const { note, notes, vault } = props;
+  return (
+    <Action.Push
+      title="Quick Look"
+      target={<NoteQuickLook note={note} showTitle={true} allNotes={notes} vault={vault} />}
+      icon={Icon.Eye}
+    />
+  );
+}
+
+export function OpenInDefaultAppAction(props: { note: Note; notes: Note[]; vault: Vault }) {
   const { note } = props;
-  return <Action.Push title="Quick Look" target={<NoteQuickLook note={note} showTitle={true} />} icon={Icon.Eye} />;
+  const [defaultApp, setDefaultApp] = useState<string>("Default App");
+  useEffect(() => {
+    getDefaultApplication(note.path).then((app) => setDefaultApp(app.name));
+  }, [note.path]);
+
+  return <Action.Open title={`Open in ${defaultApp}`} target={note.path} icon={Icon.AppWindow} />;
 }
 
 export function BookmarkNoteAction(props: { note: Note; vault: Vault }) {
@@ -188,7 +213,7 @@ export function OpenNoteInObsidianNewPaneAction(props: { note: Note; vault: Vaul
 
   return (
     <Action.Open
-      title="Open in new Pane"
+      title="Open in New Obsidian Tab"
       target={
         "obsidian://advanced-uri?vault=" +
         encodeURIComponent(vault.name) +
@@ -308,6 +333,7 @@ export function OpenNoteActions(props: { note: Note; notes: Note[]; vault: Vault
   const [vaultsWithPlugin] = vaultPluginCheck([vault], "obsidian-advanced-uri");
 
   const quicklook = <QuickLookAction note={note} notes={notes} vault={vault} />;
+  const openInDefaultApp = <OpenInDefaultAppAction note={note} notes={notes} vault={vault} />;
   const obsidian = <OpenPathInObsidianAction path={note.path} />;
   const obsidianNewPane = vaultsWithPlugin.includes(vault) ? (
     <OpenNoteInObsidianNewPaneAction note={note} vault={vault} />
@@ -319,11 +345,22 @@ export function OpenNoteActions(props: { note: Note; notes: Note[]; vault: Vault
         {quicklook}
         {obsidian}
         {obsidianNewPane}
+        {openInDefaultApp}
       </React.Fragment>
     );
   } else if (primaryAction == PrimaryAction.OpenInObsidian) {
     return (
       <React.Fragment>
+        {obsidian}
+        {obsidianNewPane}
+        {openInDefaultApp}
+        {quicklook}
+      </React.Fragment>
+    );
+  } else if (primaryAction == PrimaryAction.OpenInDefaultApp) {
+    return (
+      <React.Fragment>
+        {openInDefaultApp}
         {obsidian}
         {obsidianNewPane}
         {quicklook}
@@ -335,6 +372,7 @@ export function OpenNoteActions(props: { note: Note; notes: Note[]; vault: Vault
         {obsidianNewPane}
         {obsidian}
         {quicklook}
+        {openInDefaultApp}
       </React.Fragment>
     );
   } else {
@@ -343,6 +381,7 @@ export function OpenNoteActions(props: { note: Note; notes: Note[]; vault: Vault
         {obsidian}
         {obsidianNewPane}
         {quicklook}
+        {openInDefaultApp}
       </React.Fragment>
     );
   }
@@ -354,7 +393,7 @@ export function AppendTaskAction(props: { note: Note; vault: Vault }) {
 
   return (
     <Action.Push
-      title="Append task"
+      title="Append Task"
       target={<AppendNoteForm note={note} vault={vault} dispatch={dispatch} />}
       shortcut={{ modifiers: ["opt"], key: "a" }}
       icon={Icon.Pencil}

--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -21,6 +21,7 @@ export enum PrimaryAction {
   QuickLook = "quicklook",
   OpenInObsidian = "obsidian",
   OpenInObsidianNewPane = "newpane",
+  OpenInDefaultApp = "defaultapp",
 }
 
 export const APPLICATION_UUID = "49acc9ee-69a0-4419-9aad-5c2689ff0119";


### PR DESCRIPTION
This adds an option in the extensions preferences to set "open in the default app" as the main action. 

_Multiple commands support this so look at each command for the setting._

![CleanShot 2023-11-04 at 17 49 11](https://github.com/KevinBatdorf/obsidian-raycast/assets/1478421/70b87498-4c59-4b02-861d-c9eca5295077)

Closes https://github.com/raycast/extensions/issues/8746

This also adds the action list to the random note command, and renames "pane" to "tab" to match Obsidian's language