### PR TITLE
Add {content} template support

### DIFF
--- a/src/appendTaskCommand.tsx
+++ b/src/appendTaskCommand.tsx
@@ -32,8 +32,7 @@ export default function AppendTask(props: { arguments: appendTaskArgs }) {
 
   useEffect(() => {
     async function getContent() {
-      const withTemplate = appendTemplate ? appendTemplate + text : text;
-      const content = await applyTemplates(withTemplate);
+      const content = await applyTemplates(text, appendTemplate);
       setContent(content);
     }
 

--- a/src/dailyNoteAppendCommand.tsx
+++ b/src/dailyNoteAppendCommand.tsx
@@ -25,8 +25,7 @@ export default function DailyNoteAppend(props: { arguments: DailyNoteAppendArgs 
   const [content, setContent] = useState("");
   useEffect(() => {
     async function getContent() {
-      const withTemplate = appendTemplate ? appendTemplate + text : text;
-      const content = await applyTemplates(withTemplate);
+      const content = await applyTemplates(text, appendTemplate);
       setContent(content);
     }
     getContent();

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -264,41 +264,39 @@ async function ISO8601_week_no(dt: Date) {
   return 1 + Math.ceil((firstThursday - tdt.getTime()) / 604800000);
 }
 
-export async function applyTemplates(content: string) {
+/** both content and template might have templates to apply */
+export async function applyTemplates(content: string, template = "") {
   const date = new Date();
   const week = await ISO8601_week_no(date);
   const hours = date.getHours().toString().padStart(2, "0");
   const minutes = date.getMinutes().toString().padStart(2, "0");
   const seconds = date.getSeconds().toString().padStart(2, "0");
-
   const timestamp = Date.now().toString();
-
-  content = content.replaceAll("{time}", date.toLocaleTimeString());
-  content = content.replaceAll("{date}", date.toLocaleDateString());
-
-  content = content.replaceAll("{week}", week.toString().padStart(2, "0"));
-
-  content = content.replaceAll("{year}", date.getFullYear().toString());
-  content = content.replaceAll("{month}", MONTH_NUMBER_TO_STRING[date.getMonth()]);
-  content = content.replaceAll("{day}", DAY_NUMBER_TO_STRING[date.getDay()]);
-
-  content = content.replaceAll("{hour}", hours);
-  content = content.replaceAll("{minute}", minutes);
-  content = content.replaceAll("{second}", seconds);
-  content = content.replaceAll("{millisecond}", date.getMilliseconds().toString());
-
-  content = content.replaceAll("{timestamp}", timestamp);
-  content = content.replaceAll("{zettelkastenID}", timestamp);
-
   const clipboard = await getClipboardContent();
-  content = content.replaceAll("{clipboard}", clipboard);
-  content = content.replaceAll("{clip}", clipboard);
 
-  content = content.replaceAll("{\n}", "\n");
-  content = content.replaceAll("{newline}", "\n");
-  content = content.replaceAll("{nl}", "\n");
-
-  return content;
+  const preprocessed = template.includes("{content}")
+    ? template
+    : // If the append template does not have {content} then add it to the end
+      template + content;
+  return preprocessed
+    .replaceAll("{content}", content)
+    .replaceAll("{time}", date.toLocaleTimeString())
+    .replaceAll("{date}", date.toLocaleDateString())
+    .replaceAll("{week}", week.toString().padStart(2, "0"))
+    .replaceAll("{year}", date.getFullYear().toString())
+    .replaceAll("{month}", MONTH_NUMBER_TO_STRING[date.getMonth()])
+    .replaceAll("{day}", DAY_NUMBER_TO_STRING[date.getDay()])
+    .replaceAll("{hour}", hours)
+    .replaceAll("{minute}", minutes)
+    .replaceAll("{second}", seconds)
+    .replaceAll("{millisecond}", date.getMilliseconds().toString())
+    .replaceAll("{timestamp}", timestamp)
+    .replaceAll("{zettelkastenID}", timestamp)
+    .replaceAll("{clipboard}", clipboard)
+    .replaceAll("{clip}", clipboard)
+    .replaceAll("{\n}", "\n")
+    .replaceAll("{newline}", "\n")
+    .replaceAll("{nl}", "\n");
 }
 
 export async function appendSelectedTextTo(note: Note) {

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -275,9 +275,8 @@ export async function applyTemplates(content: string, template = "") {
   const clipboard = await getClipboardContent();
 
   const preprocessed = template.includes("{content}")
-    ? template
-    : // If the append template does not have {content} then add it to the end
-      template + content;
+    ? template // Has {content} e.g. | {hour}:{minute} | {content} |
+    : template + content; // Does not have {content}, then add it to the end
   return preprocessed
     .replaceAll("{content}", content)
     .replaceAll("{time}", date.toLocaleTimeString())


### PR DESCRIPTION
Adds support for template patterns like `| {hour}:{minute} | {content} |`

Closes https://github.com/KevinBatdorf/obsidian-raycast/issues/49