### PR TITLE
Add custom config name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Adds extension setting to open note in default application
 - Adds quick actions to the Random Note command
 - Adds support for using {content} in templates
+- Adds config file name option to override `.obsidian` config file name
 
 ## [Update search starting sort] - 2023-10-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [New features and bugfixes] - 2023-10-12
 - Adds extension setting to open note in default application
 - Adds quick actions to the Random Note command
+- Adds support for using {content} in templates
 
 ## [Update search starting sort] - 2023-10-12
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,15 @@
       "description": "Specify the path or multiple paths (comma separated) to your vault/vaults"
     },
     {
+      "name": "configFileName",
+      "type": "textfield",
+      "placeholder": ".obsidian",
+      "title": "Config filename",
+      "required": false,
+      "default": ".obsidian",
+      "description": "Override the vault config filename (default: .obsidian)"
+    },
+    {
       "name": "excludedFolders",
       "type": "textfield",
       "placeholder": "folder1, folder2, ...",

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -68,8 +68,9 @@ export function getNoteFileContent(path: string, filter = false) {
 
 export function vaultPluginCheck(vaults: Vault[], plugin: string) {
   const vaultsWithoutPlugin: Vault[] = [];
+  const { configFileName } = getPreferenceValues();
   vaults = vaults.filter((vault: Vault) => {
-    const communityPluginsPath = vault.path + "/.obsidian/community-plugins.json";
+    const communityPluginsPath = `${vault.path}/${configFileName}/community-plugins.json`;
     if (!fs.existsSync(communityPluginsPath)) {
       vaultsWithoutPlugin.push(vault);
     } else {
@@ -86,7 +87,8 @@ export function vaultPluginCheck(vaults: Vault[], plugin: string) {
 }
 
 export function getUserIgnoreFilters(vault: Vault) {
-  const appJSONPath = vault.path + "/.obsidian/app.json";
+  const { configFileName } = getPreferenceValues();
+  const appJSONPath = `${vault.path}/${configFileName}/app.json`;
   if (!fs.existsSync(appJSONPath)) {
     return [];
   } else {
@@ -96,7 +98,8 @@ export function getUserIgnoreFilters(vault: Vault) {
 }
 
 export function getBookmarkedJSON(vault: Vault) {
-  const bookmarkedNotesPath = vault.path + "/.obsidian/bookmarks.json";
+  const { configFileName } = getPreferenceValues();
+  const bookmarkedNotesPath = `${vault.path}/${configFileName}/bookmarks.json`;
   if (!fs.existsSync(bookmarkedNotesPath)) {
     return [];
   } else {
@@ -105,7 +108,8 @@ export function getBookmarkedJSON(vault: Vault) {
 }
 
 export function writeToBookmarkedJSON(vault: Vault, bookmarkedNotes: Note[]) {
-  const bookmarkedNotesPath = vault.path + "/.obsidian/bookmarks.json";
+  const { configFileName } = getPreferenceValues();
+  const bookmarkedNotesPath = `${vault.path}/${configFileName}/bookmarks.json`;
   fs.writeFileSync(bookmarkedNotesPath, JSON.stringify({ items: bookmarkedNotes }));
 }
 
@@ -425,12 +429,16 @@ function validFile(file: string, includes: string[]) {
 
 export function walkFilesHelper(dirPath: string, exFolders: string[], fileEndings: string[], arrayOfFiles: string[]) {
   const files = fs.readdirSync(dirPath);
+  const { configFileName } = getPreferenceValues();
 
   arrayOfFiles = arrayOfFiles || [];
 
   for (const file of files) {
     const next = fs.statSync(dirPath + "/" + file);
-    if (next.isDirectory() && validFile(file, [".git", ".obsidian", ".trash", ".excalidraw", ".mobile"])) {
+    if (
+      next.isDirectory() &&
+      validFile(file, [".git", ".obsidian", ".trash", ".excalidraw", ".mobile", configFileName])
+    ) {
       arrayOfFiles = walkFilesHelper(dirPath + "/" + file, exFolders, fileEndings, arrayOfFiles);
     } else {
       if (
@@ -438,6 +446,7 @@ export function walkFilesHelper(dirPath: string, exFolders: string[], fileEnding
         file !== ".md" &&
         !file.includes(".excalidraw") &&
         !dirPath.includes(".obsidian") &&
+        !dirPath.includes(configFileName) &&
         validFolder(dirPath, exFolders)
       ) {
         arrayOfFiles.push(path.join(dirPath, "/", file));

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -70,7 +70,8 @@ export function vaultPluginCheck(vaults: Vault[], plugin: string) {
   const vaultsWithoutPlugin: Vault[] = [];
   const { configFileName } = getPreferenceValues();
   vaults = vaults.filter((vault: Vault) => {
-    const communityPluginsPath = `${vault.path}/${configFileName}/community-plugins.json`;
+    const communityPluginsPath = `${vault.path}/${configFileName || ".obsidian"}/community-plugins.json`;
+    console.log(communityPluginsPath, fs.existsSync(communityPluginsPath));
     if (!fs.existsSync(communityPluginsPath)) {
       vaultsWithoutPlugin.push(vault);
     } else {
@@ -88,7 +89,7 @@ export function vaultPluginCheck(vaults: Vault[], plugin: string) {
 
 export function getUserIgnoreFilters(vault: Vault) {
   const { configFileName } = getPreferenceValues();
-  const appJSONPath = `${vault.path}/${configFileName}/app.json`;
+  const appJSONPath = `${vault.path}/${configFileName || ".obsidian"}/app.json`;
   if (!fs.existsSync(appJSONPath)) {
     return [];
   } else {
@@ -99,7 +100,7 @@ export function getUserIgnoreFilters(vault: Vault) {
 
 export function getBookmarkedJSON(vault: Vault) {
   const { configFileName } = getPreferenceValues();
-  const bookmarkedNotesPath = `${vault.path}/${configFileName}/bookmarks.json`;
+  const bookmarkedNotesPath = `${vault.path}/${configFileName || ".obsidian"}/bookmarks.json`;
   if (!fs.existsSync(bookmarkedNotesPath)) {
     return [];
   } else {
@@ -109,7 +110,7 @@ export function getBookmarkedJSON(vault: Vault) {
 
 export function writeToBookmarkedJSON(vault: Vault, bookmarkedNotes: Note[]) {
   const { configFileName } = getPreferenceValues();
-  const bookmarkedNotesPath = `${vault.path}/${configFileName}/bookmarks.json`;
+  const bookmarkedNotesPath = `${vault.path}/${configFileName || ".obsidian"}/bookmarks.json`;
   fs.writeFileSync(bookmarkedNotesPath, JSON.stringify({ items: bookmarkedNotes }));
 }
 
@@ -420,7 +421,7 @@ export function isNote(note: Note | undefined): note is Note {
 
 function validFile(file: string, includes: string[]) {
   for (const include of includes) {
-    if (file.includes(include)) {
+    if (include && file.includes(include)) {
       return false;
     }
   }


### PR DESCRIPTION
This adds support for a custom config file name.

How to set it: https://help.obsidian.md/Customization/Config+folders

It will default to .obsidian if not set (or if the user deletes it entirely)

Closes https://github.com/raycast/extensions/issues/8991

The caveat is it's all or nothing, so if you use a different name in each vault, I'll have to rethink how to add support for that. Maybe there is a way to auto-detect it? 