### PR TITLE
Fix search media  hotkey big

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Obsidian Changelog
 
+## [Fix Search Media HotKey bug] - 2024-01-17
+- Checks for defined `searchArgument` in MediaGrid value before filtering
+
 ## [Copy Note Title action] - 2024-01-17
 - Add `Copy Note Title` action
 

--- a/src/components/MediaGrid.tsx
+++ b/src/components/MediaGrid.tsx
@@ -27,7 +27,7 @@ export function MediaGrid(props: { vault: Vault; searchArguments: MediaSearchArg
   const extensions = getListOfExtensions(allMedia);
   const { imageSize } = getPreferenceValues<SearchMediaPreferences>();
 
-  const [searchText, setSearchText] = useState(searchArguments ? searchArguments.searchArgument : "");
+  const [searchText, setSearchText] = useState(searchArguments?.searchArgument ?? "");
   const list = useMemo(() => filterMedia(mediaList, searchText, notes), [mediaList, searchText]);
 
   return (

--- a/src/utils/search.tsx
+++ b/src/utils/search.tsx
@@ -35,7 +35,7 @@ export function filterNotes(notes: Note[], input: string, byContent: boolean) {
  * @returns - A list of media filtered according to the input search string
  */
 export function filterMedia(mediaList: Media[], input: string, notes: Note[]) {
-  if (input.length === 0) {
+  if (input?.length === 0) {
     return mediaList;
   }
 


### PR DESCRIPTION
Fixes a bug where adding a hotkey to the search media command crashes

RE: https://github.com/raycast/extensions/issues/9485