### PR TITLE
Remove tag toLowerCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Obsidian Changelog
 
+## [Bug fixes] - 2024-12-03
+- Fixes locale bug on Append Task command
+- Fixes issue where tags were being converted to lowercase
+
 ## [Task Creation Date] - 2024-12-03
 - Tasks added now log the creation date.
 

--- a/src/components/CreateNoteForm.tsx
+++ b/src/components/CreateNoteForm.tsx
@@ -83,7 +83,7 @@ export function CreateNoteForm(props: { vault: Vault; showTitle: boolean }) {
       />
       <Form.TagPicker id="tags" title="Tags" defaultValue={prefTag ? [prefTag] : []}>
         {parseTags()?.map((tag) => (
-          <Form.TagPicker.Item value={tag.name.toLowerCase()} title={tag.name} key={tag.key} />
+          <Form.TagPicker.Item value={tag.name} title={tag.name} key={tag.key} />
         ))}
       </Form.TagPicker>
       <Form.TextArea


### PR DESCRIPTION
Fixes a bug where tags are converted to lowercase

Closes https://github.com/KevinBatdorf/obsidian-raycast/issues/95