### PR TITLE
Add prepend option to append to daily note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Obsidian Changelog
 
+## [Prepend to Daily Note] - 2025-02-01
+- Adds prepend option to Append to Daily Note
+
 ## [Bug fixes] - 2025-01-28
 - Fixes locale bug on Append Task command
 - Fixes issue where tags were being converted to lowercase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Obsidian Changelog
 
-## [Bug fixes] - 2024-12-03
+## [Bug fixes] - 2025-01-28
 - Fixes locale bug on Append Task command
 - Fixes issue where tags were being converted to lowercase
 

--- a/package.json
+++ b/package.json
@@ -301,6 +301,15 @@
           "description": "If no heading is set, text will be appended to the end of the daily note"
         },
         {
+          "name": "prepend",
+          "type": "checkbox",
+          "label": "Prepend",
+          "title": "Prepend",
+          "required": false,
+          "description": "Prepend the text instead of appending",
+          "default": false
+        },
+        {
           "name": "silent",
           "type": "checkbox",
           "label": "Silent Mode",

--- a/src/dailyNoteAppendCommand.tsx
+++ b/src/dailyNoteAppendCommand.tsx
@@ -20,7 +20,7 @@ interface DailyNoteAppendArgs {
 export default function DailyNoteAppend(props: { arguments: DailyNoteAppendArgs }) {
   const { vaults, ready } = useObsidianVaults();
   const { text } = props.arguments;
-  const { appendTemplate, heading, vaultName, silent } = getPreferenceValues<DailyNoteAppendPreferences>();
+  const { appendTemplate, heading, vaultName, prepend, silent } = getPreferenceValues<DailyNoteAppendPreferences>();
   const [vaultsWithPlugin, vaultsWithoutPlugin] = vaultPluginCheck(vaults, "obsidian-advanced-uri");
   const [content, setContent] = useState("");
   useEffect(() => {
@@ -59,6 +59,7 @@ export default function DailyNoteAppend(props: { arguments: DailyNoteAppendArgs 
       vault: vaultToUse,
       text: content,
       heading: heading,
+      prepend: prepend,
       silent: silent,
     });
     open(target);
@@ -83,6 +84,7 @@ export default function DailyNoteAppend(props: { arguments: DailyNoteAppendArgs 
                   vault: vault,
                   text: content,
                   heading: heading,
+                  prepend: prepend,
                 })}
               />
             </ActionPanel>

--- a/src/utils/preferences.tsx
+++ b/src/utils/preferences.tsx
@@ -40,6 +40,7 @@ export interface DailyNoteAppendPreferences {
   appendTemplate?: string;
   vaultName?: string;
   heading?: string;
+  prepend?: boolean;
   silent?: boolean;
 }
 

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -445,7 +445,7 @@ export enum ObsidianTargetType {
   OpenVault = "obsidian://open?vault=",
   OpenPath = "obsidian://open?path=",
   DailyNote = "obsidian://advanced-uri?daily=true&vault=",
-  DailyNoteAppend = "obsidian://advanced-uri?daily=true&mode=append",
+  DailyNoteAppend = "obsidian://advanced-uri?daily=true",
   NewNote = "obsidian://new?vault=",
   AppendTask = "obsidian://advanced-uri?mode=append&filepath=",
 }
@@ -454,7 +454,14 @@ export type ObsidianTarget =
   | { type: ObsidianTargetType.OpenVault; vault: Vault }
   | { type: ObsidianTargetType.OpenPath; path: string }
   | { type: ObsidianTargetType.DailyNote; vault: Vault }
-  | { type: ObsidianTargetType.DailyNoteAppend; vault: Vault; text: string; heading?: string; silent?: boolean }
+  | {
+      type: ObsidianTargetType.DailyNoteAppend;
+      vault: Vault;
+      text: string;
+      heading?: string;
+      prepend?: boolean;
+      silent?: boolean;
+    }
   | { type: ObsidianTargetType.NewNote; vault: Vault; name: string; content?: string }
   | {
       type: ObsidianTargetType.AppendTask;
@@ -480,6 +487,7 @@ export function getObsidianTarget(target: ObsidianTarget) {
       const headingParam = target.heading ? "&heading=" + encodeURIComponent(target.heading) : "";
       return (
         ObsidianTargetType.DailyNoteAppend +
+        (target.prepend ? "&mode=prepend" : "&mode=append") +
         "&data=" +
         encodeURIComponent(target.text) +
         "&vault=" +


### PR DESCRIPTION
Adds a prepend option to the append to daily note command

It's a new option on the command and off by default

closes https://github.com/KevinBatdorf/obsidian-raycast/issues/90